### PR TITLE
Tentative model for WithinBand

### DIFF
--- a/Buildings_Requirements/Validation/WithinBand.mo
+++ b/Buildings_Requirements/Validation/WithinBand.mo
@@ -5,11 +5,11 @@ model WithinBand
   inner Modelica_Requirements.Verify.PrintViolations printViolations
     "Prints requirements violations"
     annotation (Placement(transformation(extent={{60,60},{80,80}})));
-  Buildings_Requirements.WithinBand reqWitBan(
+  Buildings_Requirements.WithinBand_old reqWitBan(
     text="Test whether signal is within band",
     u_max=0.5,
     u_min=-0.5) annotation (Placement(transformation(extent={{20,20},{40,40}})));
-  Buildings_Requirements.WithinBand reqWitBan1(
+  Buildings_Requirements.WithinBand_old reqWitBan1(
     text="Test whether signal is within band",
     use_activeInput=true,
     u_max=0.5,
@@ -20,7 +20,7 @@ model WithinBand
   Buildings.Controls.OBC.CDL.Logical.Sources.Constant off(k=false)
     "Outputs false"
     annotation (Placement(transformation(extent={{-60,-44},{-40,-24}})));
-  Buildings_Requirements.WithinBand reqWitBan2(
+  Buildings_Requirements.WithinBand_old reqWitBan2(
     text="Test whether signal is within band",
     use_activeInput=true,
     u_max=0.5,

--- a/Buildings_Requirements/Validation/WithinBand_corrected.mo
+++ b/Buildings_Requirements/Validation/WithinBand_corrected.mo
@@ -1,0 +1,22 @@
+within Buildings_Requirements.Validation;
+model WithinBand_corrected
+  "Example to show the correction of the WithinBand model"
+  extends Modelica.Icons.Example;
+  Buildings_Requirements.WithinBand reqWitBan(
+    name="Tentative",
+    u_max=1,
+    u_min=-1) annotation (Placement(transformation(extent={{0,20},{20,40}})));
+  WithinBand_old reqWitBan_old(
+    name="Previous",
+    u_max=1,
+    u_min=-1) annotation (Placement(transformation(extent={{0,-40},{20,-20}})));
+  Modelica.Blocks.Sources.Constant const(k=0)
+    annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
+equation
+  connect(const.y, reqWitBan_old.u) annotation (Line(points={{-39,0},{-20,0},{
+          -20,-26},{-1,-26}}, color={0,0,127}));
+  connect(const.y, reqWitBan.u) annotation (Line(points={{-39,0},{-20,0},{-20,
+          34},{-1,34}}, color={0,0,127}));
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
+        coordinateSystem(preserveAspectRatio=false)));
+end WithinBand_corrected;

--- a/Buildings_Requirements/Validation/package.order
+++ b/Buildings_Requirements/Validation/package.order
@@ -2,3 +2,4 @@ GreaterEqual
 MinimumDuration
 StableContinuousSignal
 WithinBand
+WithinBand_corrected

--- a/Buildings_Requirements/WithinBand_old.mo
+++ b/Buildings_Requirements/WithinBand_old.mo
@@ -1,5 +1,5 @@
 within Buildings_Requirements;
-block WithinBand
+block WithinBand_old
   "Block that verifies whether a signal is within a lower and upper bound when the test is active"
   extends Buildings_Requirements.BaseClasses.PartialSignalTestWhenActive;
 
@@ -25,10 +25,10 @@ protected
     "Switch to disable activation of verification. This can avoid state events if the verification is inactive"
     annotation (Placement(transformation(extent={{-20,40},{0,60}})));
 
-public
-  Modelica.Blocks.Logical.Not not1
-    annotation (Placement(transformation(extent={{70,40},{90,60}})));
 equation
+  connect(witBan.y, booToInt.u)
+    annotation (Line(points={{53,50},{60,50},{60,-14},{-26,-14},{-26,-30},{-22,
+          -30}},                                 color={255,0,255}));
   connect(truDel.y, swi.u2) annotation (Line(points={{-58,-40},{-34,-40},{-34,
           50},{-22,50}},
                 color={255,0,255}));
@@ -46,10 +46,6 @@ equation
   connect(intSwi.u2, truDel.y)
     annotation (Line(points={{18,-50},{-34,-50},{-34,-40},{-58,-40}},
                                               color={255,0,255}));
-  connect(witBan.y, not1.u)
-    annotation (Line(points={{53,50},{68,50}}, color={255,0,255}));
-  connect(not1.y, booToInt.u) annotation (Line(points={{91,50},{96,50},{96,-10},
-          {-26,-10},{-26,-30},{-22,-30}}, color={255,0,255}));
   annotation (
     defaultComponentName="reqWitBan",
   Diagram(coordinateSystem(extent={{-100,-100},{100,100}})), Icon(
@@ -114,4 +110,4 @@ December 19, 2024, by Michael Wetter:<br/>
 First implementation.
 </li>
 </html>"));
-end WithinBand;
+end WithinBand_old;

--- a/Buildings_Requirements/package.order
+++ b/Buildings_Requirements/package.order
@@ -3,5 +3,6 @@ GreaterEqual
 MinimumDuration
 StableContinuousSignal
 WithinBand
+WithinBand_old
 Validation
 BaseClasses


### PR DESCRIPTION
The behavior of `WithinBand` is incorrect, as shown in `Buildings_Requirements.Validation.WithinBand_corrected`
I changed the model `WithinBand` and kept the old one as `WithinBand_old`.
There may be a better way to correct the model (I added a `not` block)