### PR TITLE
Issue2 Modification of WithinBand 

### DIFF
--- a/Buildings_Requirements/BaseClasses/PartialSignalTestWhenActive.mo
+++ b/Buildings_Requirements/BaseClasses/PartialSignalTestWhenActive.mo
@@ -30,9 +30,8 @@ protected
   Modelica_Requirements.LogicalBlocks.IntegerToProperty ItoP1
     "Integer to property conversion"
     annotation (Placement(transformation(extent={{44,-60},{64,-40}})));
-  Buildings.Controls.OBC.CDL.Conversions.BooleanToInteger booToInt(
-    final integerTrue=1,
-    final integerFalse=3)
+  Buildings.Controls.OBC.CDL.Conversions.BooleanToInteger booToInt(final
+      integerTrue=3, final integerFalse=1)
       "Boolean to integer conversion"
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Buildings.Controls.OBC.CDL.Integers.Switch intSwi

--- a/Buildings_Requirements/GreaterEqual.mo
+++ b/Buildings_Requirements/GreaterEqual.mo
@@ -13,8 +13,7 @@ block GreaterEqual
       Placement(transformation(extent={{-140,0},{-100,40}}),
         iconTransformation(extent={{-120,10},{-100,30}})));
 
-  Buildings.Controls.OBC.CDL.Reals.Less    lesThr(
-                                               h=0)
+  Buildings.Controls.OBC.CDL.Reals.Greater gre(h=0)
     "Tests wether u1 is less than u2"
     annotation (Placement(transformation(extent={{20,50},{40,70}})));
 protected
@@ -22,18 +21,17 @@ protected
     "Switch to disable activation of verification. This can avoid state events if the verification is inactive"
     annotation (Placement(transformation(extent={{-20,30},{0,50}})));
 equation
-  connect(lesThr.y, booToInt.u)
-    annotation (Line(points={{42,60},{52,60},{52,-10},{-26,-10},{-26,-30},{-22,
-          -30}},                                 color={255,0,255}));
-  connect(lesThr.u1, u_max) annotation (Line(points={{18,60},{-120,60}},
-                      color={0,0,127}));
+  connect(gre.y, booToInt.u) annotation (Line(points={{42,60},{52,60},{52,-10},
+          {-26,-10},{-26,-30},{-22,-30}}, color={255,0,255}));
+  connect(gre.u1, u_max)
+    annotation (Line(points={{18,60},{-120,60}}, color={0,0,127}));
   connect(truDel.y, swi.u2) annotation (Line(points={{-58,-40},{-34,-40},{-34,
           40},{-22,40}},
                     color={255,0,255}));
   connect(swi.u1, u_min) annotation (Line(points={{-22,48},{-90,48},{-90,20},{
           -120,20}}, color={0,0,127}));
-  connect(swi.y, lesThr.u2) annotation (Line(points={{2,40},{10,40},{10,52},{18,
-          52}}, color={0,0,127}));
+  connect(swi.y, gre.u2) annotation (Line(points={{2,40},{10,40},{10,52},{18,52}},
+        color={0,0,127}));
   connect(swi.u3, u_max) annotation (Line(points={{-22,32},{-40,32},{-40,60},{
           -120,60}}, color={0,0,127}));
   connect(act.y, swi.u2) annotation (Line(points={{-58,-10},{-30,-10},{-30,40},

--- a/Buildings_Requirements/StableContinuousSignal.mo
+++ b/Buildings_Requirements/StableContinuousSignal.mo
@@ -12,7 +12,7 @@ block StableContinuousSignal
       Placement(transformation(extent={{-140,20},{-100,60}}),
         iconTransformation(extent={{-120,30},{-100,50}})));
 
-  Buildings.Controls.OBC.CDL.Reals.GreaterThreshold greThr(
+  Buildings.Controls.OBC.CDL.Reals.LessThreshold    lesThr(
     final t=t,
     h=t/20)
     "Check whether signal is stable"
@@ -48,7 +48,7 @@ protected
     "Moving average of the signal"
     annotation (Placement(transformation(extent={{0,30},{20,50}})));
 equation
-  connect(greThr.y, booToInt.u) annotation (Line(points={{92,40},{96,40},{96,
+  connect(lesThr.y, booToInt.u) annotation (Line(points={{92,40},{96,40},{96,
           -12},{-26,-12},{-26,-30},{-22,-30}},
                                           color={255,0,255}));
   connect(truDel.y, movAve.active) annotation (Line(points={{-58,-40},{-34,-40},
@@ -59,7 +59,7 @@ equation
     annotation (Line(points={{-32,40},{-39,40}}, color={0,0,127}));
   connect(act.y, movAve.active) annotation (Line(points={{-58,-10},{10,-10},{10,
           28}},     color={255,0,255}));
-  connect(swiVer.y, greThr.u)
+  connect(swiVer.y,lesThr. u)
     annotation (Line(points={{62,40},{68,40}}, color={0,0,127}));
   connect(truDelVer.u, truDel.y) annotation (Line(points={{-22,10},{-34,10},{-34,
           -40},{-58,-40}}, color={255,0,255}));


### PR DESCRIPTION
The following models were modified:
- `Buildings_Requirements.BaseClasses.PartialSignalTestWhenActive`: `booToInt` now takes the value 3 when the boolean is `True` and 1 when the boolean is `False`, this allows to have a coherent behavior with `Modelica_Requirements.LogicalBlocks.IntegerToProperty`
- `Buildings_Requirements.GreaterEqual` now uses the model `Buildings.Controls.OBC.CDL.Reals.Greater` instead of `Buildings.Controls.OBC.CDL.Reals.Less`. This leads to a slight behavioral change of the model. The requirement is not satisfied if `u_max > u_min`, whereas previously it was when `u_max >= u_min`. This could be changed using `Modelica.Blocks.Logical.GreaterEqual` instead of `Buildings.Controls.OBC.CDL.Reals.Greater`
- `Buildings_Requirements.StableContinuousSignal` changing the model `Buildings.Controls.OBC.CDL.Reals.GreaterThreshold` to `Buildings.Controls.OBC.CDL.Reals.LessThreshold`. This leads to less restrictive conditions to pass with the same hysteresis: `GreaterThreshold` turns True when the inlet signal is greater than t (defined by the user), `LessThreshold` becomes wrong when the inlet signal is greater than t + threshold